### PR TITLE
App start & quit with KBOS 

### DIFF
--- a/disable_bluetooth.sh
+++ b/disable_bluetooth.sh
@@ -1,5 +1,8 @@
 #!/bin/bash 
 /usr/local/bin/blueutil --power 0
 
+# Add App which quit when lid is closed
+osascript -e 'quit app "APP NAME"' #Example: osascript -e 'quit app "HandsFree 2"'
+
 # Uncomment to debug
 # echo "[$(date)] :attempting to disable bluetooth" >> ~/bluetooth.log

--- a/enable_bluetooth.sh
+++ b/enable_bluetooth.sh
@@ -1,5 +1,8 @@
 #!/bin/bash 
 /usr/local/bin/blueutil --power 1
 
+# Add App which starts when lid is open
+open -a "APP NAME" #Example open -a "HandsFree 2"
+
 # Uncomment to debug
 # echo "[$(date)] :attempting to enable bluetooth" >> ~/bluetooth.log


### PR DESCRIPTION
This can be of great use if someone is a fan of Apple Continuity Mode but it's restricted to iPhone users only.

Now similar experience can be delivered on Android & Mac while using apps like KdeConnect, AirDroid, HandsFree 2, etc.