### PR TITLE
Make scripts indepenent of Homebrew prefix.

### DIFF
--- a/disable_bluetooth.sh
+++ b/disable_bluetooth.sh
@@ -1,5 +1,5 @@
 #!/bin/bash 
-/usr/local/bin/blueutil --power 0
+blueutil --power 0
 
 # Uncomment to debug
 # echo "[$(date)] :attempting to disable bluetooth" >> ~/bluetooth.log

--- a/enable_bluetooth.sh
+++ b/enable_bluetooth.sh
@@ -1,5 +1,5 @@
 #!/bin/bash 
-/usr/local/bin/blueutil --power 1
+blueutil --power 1
 
 # Uncomment to debug
 # echo "[$(date)] :attempting to enable bluetooth" >> ~/bluetooth.log

--- a/setup.sh
+++ b/setup.sh
@@ -94,17 +94,24 @@ echo "***********************"
 echo "Preparing sleep scripts"
 echo "***********************" 
 
+# Determine and escape absolute paths of sleepwatcher and Blueutil
+SLEEPWATCHER_PATH=$(which sleepwatcher | sed 's_/_\\/_g')
+BLUEUTIL_PATH=$(which blueutil | sed 's_/_\\/_g')
+
 # Copy sleepscripts to user directory
 mkdir -p ${SLEEP_SCRIPTS_DIR} || exit 1;
-cp ./disable_bluetooth.sh ${SLEEP_SCRIPTS_DIR} || exit 1;
-cp ./enable_bluetooth.sh ${SLEEP_SCRIPTS_DIR} || exit 1;
+sed "s/blueutil/${BLUEUTIL_PATH}/" ./disable_bluetooth.sh > \
+    ${SLEEP_SCRIPTS_DIR}/disable_bluetooth.sh || exit 1;
+sed "s/blueutil/${BLUEUTIL_PATH}/" ./enable_bluetooth.sh > \
+    ${SLEEP_SCRIPTS_DIR}/enable_bluetooth.sh || exit 1;
 chmod +x ${SLEEP_SCRIPTS_DIR}/* || exit 1;
-echo "** sleep scripts copied to ~/.sleepscripts"
+echo "** sleep scripts copied to ${SLEEP_SCRIPTS_DIR}"
 
 # Copy plist to ~/Library/LaunchAgents - after creating the directory if it doesn't exist 
 mkdir -p ${LAUNCH_AGENTS_PATH} || exit 1;
-cp ./sleepwatch_bluetooth.plist ${LAUNCH_AGENTS_PATH} || exit 1;
-echo "** sleepwatch_bluetooth.plist copied to  ${LAUNCH_AGENTS_PATH}"
+sed "s/sleepwatcher/${SLEEPWATCHER_PATH}/" ./sleepwatch_bluetooth.plist > \
+    ${LAUNCH_AGENTS_PATH}/sleepwatch_bluetooth.plist || exit 1;
+echo "** sleepwatch_bluetooth.plist copied to ${LAUNCH_AGENTS_PATH}"
 launchctl load ${KBOS_PLIST_PATH}
 
 echo " "

--- a/sleepwatch_bluetooth.plist
+++ b/sleepwatch_bluetooth.plist
@@ -6,7 +6,7 @@
 	<string>killBluetooth on sleep</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>/usr/local/sbin/sleepwatcher</string>
+		<string>sleepwatcher</string>
 		<string>-V</string>
 		<string>-s ~/.sleepscripts/disable_bluetooth.sh</string>
 		<string>-w ~/.sleepscripts/enable_bluetooth.sh</string>


### PR DESCRIPTION
The current setup assumes that Homebrew installs sleepwatcher and Blueutil in `/usr/local/bin/` which seems no longer the default. This PR changes `setup.sh` so as to determine the actual location of the two binaries and patches the scripts accordingly during setup.

This fixes #6 and #8 (at least on my machine).